### PR TITLE
feat/llm web search

### DIFF
--- a/autoload/kisuke/handlers.vim
+++ b/autoload/kisuke/handlers.vim
@@ -97,10 +97,16 @@ func s:handle_stream(reply)
       call setbufline(g:kisuke.state.buf_nr, s:kisuke.state.response_start_line + l:index, line)
     endif
 
-    normal! G
-
     let l:index += 1
   endfor
+
+  call s:handle_incremental_syntax()
+endfunc
+
+func! s:handle_incremental_syntax()
+  if exists('*kisuke#syntax#setup_incremental')
+    call kisuke#syntax#setup_incremental()
+  endif
 endfunc
 
 func! s:handle_stream_start()

--- a/autoload/kisuke/syntax.vim
+++ b/autoload/kisuke/syntax.vim
@@ -21,12 +21,20 @@ func! kisuke#syntax#setup()
   syntax match KisukePrompt /^Prompt >/
   syntax match KisukeResponse /^Kisuke >/
   syntax match KisukeSystem /^> .*$/
+  syntax match KisukeSearch /^\[SEARCH\].*$/
+  syntax match KisukeFetch /^\[FETCH\].*$/
+  syntax match KisukeInfo /^\[INFO\].*$/
+  syntax match KisukeUsage /^\[USAGE\].*$/
 
   call s:process_code_blocks(l:current_buf)
 
   hi def link KisukePrompt Statement
   hi def link KisukeResponse Identifier
   hi def link KisukeSystem Special
+  hi def link KisukeSearch WarningMsg
+  hi def link KisukeFetch Function
+  hi def link KisukeInfo Comment
+  hi def link KisukeUsage Type
   hi def link KisukeCodeDelimiter Delimiter
 endfunc
 

--- a/src/utils/initials.ts
+++ b/src/utils/initials.ts
@@ -25,9 +25,9 @@ CRITICAL CONTEXT AWARENESS:
 - Be thorough in first response when context is provided
 
 Communication Style:
-- Be direct and concise
+- Be direct and concise like linux developers
 - No unnecessary encouragement or fluff
-- Explain complex concepts simply
+- Explain complex concepts simply with technical precision
 - Mention trade-offs when they matter
 - Suggest improvements without being preachy
 
@@ -39,6 +39,7 @@ FORMAT REQUIREMENTS (ABSOLUTELY CRITICAL):
 - NO empty lines between paragraphs in text sections
 - Code blocks MUST have exactly ONE empty line before and after
 - Always add some text to beginning of your answers, first characters or first line of your answer should not be code block delimiter backticks
+- Keep explanations terse and technical
 
 CODE BLOCK RULES (ESSENTIAL FOR VIM RENDERING):
 - Start with exactly three backticks followed immediately by language name
@@ -69,10 +70,18 @@ Code Standards:
 - Add comments only for non-obvious logic
 - Follow language conventions
 - Consider edge cases
+- Prefer concise implementations over verbose ones
+
+General Characteristics:
+- Technical precision without verbosity
+- Direct problem-solving approach
+- Clear identification of root causes
+- Efficient solution patterns
+- Minimal but sufficient explanations
 
 Remember:
 - User works in vim and values understanding code
-- User wants to grow as a developer
+- User wants to grow as a developer with technical depth
 - Be a coach, not a code generator
 - Quality over quantity in explanations
 `;


### PR DESCRIPTION
- **feat: enable web search**
  - anthropic sdk configured and web search enabled on llm calls
  - information outputs added to generation process, like searching web or
    usage statistics
  - vim chat buffer syntax styling improved for displaying new info
    outputs
  

- **refactor: stream response handling improved**
  - while llm sends stream response cursor and usage no longer blocked,
    you can switch to different buffers
  - no longer automatic scroll to end while streamed response is incoming,
    you can move in kisuke buffer or any other buffer and move up or down
  as you like
  - system prompt improvements in initials ts file
  