### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,4 +1,6 @@
 name: Code Quality Checks
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/dorukozerr/kisuke.vim/security/code-scanning/1](https://github.com/dorukozerr/kisuke.vim/security/code-scanning/1)

To fix the problem, add the `permissions` key to the workflow or the specific job to explicitly restrict the GITHUB_TOKEN permissions to the minimum required. For a workflow that simply runs code quality checks (linting and formatting), only read access to repository contents is needed. The recommended fix is to add `permissions: contents: read` immediately below the workflow `name:` at the top level, making it apply universally to all jobs in this workflow. Alternatively, you could add it under each job, but the top-level placement is cleaner and follows the recommendation. No new imports or definitions are needed; only a single line should be added near the top of .github/workflows/code-quality.yml, right beneath `name: Code Quality Checks`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
